### PR TITLE
Migrate to Biome v2

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -42,11 +42,10 @@
         "useImportType": "error",
         "useExportType": "error",
         "useConst": "error",
-        "useTemplate": "error"
-      },
-      "nursery": {
+        "useTemplate": "error",
         "useConsistentCurlyBraces": "error"
-      }
+      },
+      "nursery": {}
     }
   },
   "javascript": {
@@ -56,10 +55,8 @@
       "semicolons": "always"
     }
   },
-  "organizeImports": {
-    "enabled": true
-  },
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "files": {
-    "ignore": ["**/node_modules/**", "**/dist/**", "**/build/**"]
+    "includes": ["**", "!**/node_modules/**", "!**/dist/**", "!**/build/**"]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kontent-ai/biome-config",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kontent-ai/biome-config",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "peerDependencies": {
         "@biomejs/biome": "^1.9.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontent-ai/biome-config",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Biome configuration shared for Kontent.ai projects",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   "author": "Jiri Lojda",
   "license": "MIT",
   "peerDependencies": {
-    "@biomejs/biome": "^1.9.4"
+    "@biomejs/biome": "^2.1.2"
   }
 }


### PR DESCRIPTION
## Summary
- Updated Biome peer dependency from v1.9.4 to v2.1.2
- Migrated configuration to Biome v2 format
- Bumped package version to 0.5.0

## Breaking Changes
This update includes breaking changes for consumers of this package:
- Requires Biome v2.x (peer dependency)
- Configuration format has changed (though the migration is handled automatically by Biome)

## Configuration Changes
- `organizeImports` moved to `assist.actions.source.organizeImports`
- `files.ignore` replaced with `files.includes` using negated patterns
- `useConsistentCurlyBraces` rule moved from `nursery` to `style` group

## Test plan
- [ ] Run `npm install` to install Biome v2
- [ ] Test that formatting works correctly
- [ ] Verify linting rules still apply as expected
- [ ] Check that import organization functions properly

🤖 Generated with [Claude Code](https://claude.ai/code)