### PR TITLE
Migrate to Biome v2.0

### DIFF
--- a/biome.react.json
+++ b/biome.react.json
@@ -9,6 +9,6 @@
     }
   },
   "files": {
-    "ignore": ["**/node_modules/**", "**/dist/**", "**/build/**"]
+    "includes": ["**", "!**/node_modules/**", "!**/dist/**", "!**/build/**"]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kontent-ai/biome-config",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kontent-ai/biome-config",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "peerDependencies": {
         "@biomejs/biome": "^1.9.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontent-ai/biome-config",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Biome configuration shared for Kontent.ai projects",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- Migrated `biome.react.json` to be compatible with Biome v2.0
- Updated file patterns from deprecated `ignore` field to new `includes` glob syntax
- Bumped package version to 0.5.1

## Changes
- Updated `biome.react.json` to use `includes` instead of deprecated `ignore` field for file patterns
- Bumped version to 0.5.1 in package.json and package-lock.json

## Migration Details
The main change is replacing the deprecated file pattern syntax:
```json
// Before (deprecated in v2)
"files": {
  "ignore": ["**/node_modules/**", "**/dist/**", "**/build/**"]
}

// After (v2 format)
"files": {
  "includes": ["**", "\!**/node_modules/**", "\!**/dist/**", "\!**/build/**"]
}
```

## Test plan
- [ ] Verify React configuration works with Biome v2.0+
- [ ] Test that file ignoring/including patterns work correctly with the new syntax
- [ ] Ensure `useHookAtTopLevel` and other React-specific rules still function properly